### PR TITLE
Tobler refactor roadmap

### DIFF
--- a/examples/harmonizing_community_example.ipynb
+++ b/examples/harmonizing_community_example.ipynb
@@ -4,6 +4,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Table of Contents\n",
+    "* [Harmonizing multiple sets of polygons with `tobler`](#Harmonizing-multiple-sets-of-polygons-with-tobler)\n",
+    "\t* [First steps](#First-steps)\n",
+    "\t\t* [Visualizing these 3 set of polygons](#Visualizing-these-3-set-of-polygons)\n",
+    "\t\t* [Creating a list of all the GeoDataFrames](#Creating-a-list-of-all-the-GeoDataFrames)\n",
+    "* [Harmonizing the geodataframes with different methods](#Harmonizing-the-geodataframes-with-different-methods)\n",
+    "\t* [Area Interpolation Method](#Area-Interpolation-Method)\n",
+    "\t* [Raster Land Cover Area method: National Land Cover Dataset (NLCD)](#Raster-Land-Cover-Area-method:-National-Land-Cover-Dataset-%28NLCD%29)\n",
+    "* [Comparing both methods in terms of the values generated for all variables](#Comparing-both-methods-in-terms-of-the-values-generated-for-all-variables)\n",
+    "* [Constrained Checks (overall population)](#Constrained-Checks-%28overall-population%29)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Harmonizing multiple sets of polygons with `tobler`"
    ]
   },
@@ -47,6 +63,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## First steps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "This example uses all census data that the user must provide your own copy of the external database. A step-by-step procedure for downloading the data can be found here: https://github.com/spatialucr/geosnap/tree/master/geosnap/data. After the user download the zip files, you must provide the path to these files."
    ]
   },
@@ -59,7 +82,8 @@
     "import geosnap\n",
     "from geosnap.data.data import read_ltdb\n",
     "\n",
-    "os.chdir('path_to_zipfiles')\n",
+    "#os.chdir('path_to_zipfiles')\n",
+    "os.chdir('C:\\\\Users\\\\renan\\\\Desktop\\\\osnap_data')\n",
     "\n",
     "sample = \"LTDB_Std_All_Sample.zip\"\n",
     "full = \"LTDB_Std_All_fullcount.zip\"\n",
@@ -579,8 +603,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Creating a list of all the GeoDataFrames\n",
-    "\n",
+    "### Creating a list of all the GeoDataFrames"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The input of the `harmonize` function is a list of GeoDataFrame where it is present both target dataset and all source datasets. All the variables that are going to harmonized should have the same name  among all source datasets. We call this set a *community*."
    ]
   },
@@ -720,7 +749,7 @@
       "Harmonizing extensive variable n_total_pop of the year 2010.\n",
       "Harmonizing extensive variable n_white_under_15 of the year 2010.\n",
       "Harmonizing intensive variable p_white_under_15 of the year 2010.\n",
-      "Time taken (in seconds): 1.883812427520752\n"
+      "Time taken (in seconds): 2.0715413093566895\n"
      ]
     }
    ],
@@ -882,22 +911,35 @@
     "curl -o /tmp/NLCD2011_LC_Pennsylvania.zip \"https://s3-us-west-2.amazonaws.com/prd-tnm/StagedProducts/NLCD/data/2011/landcover/states/NLCD2011_LC_Pennsylvania.zip?ORIG=513_SBDDG\"\n",
     "\n",
     "unzip -d /tmp /tmp/NLCD2011_LC_Pennsylvania.zip\n",
-    "```\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Then in the same directory as this notebook do\n",
     "\n",
     "```\n",
     "ln -s /tmp/NLCD2011_LC_Pennsylvania.tif\n",
-    "```\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Now, you need to specify the file path of the unzipped file that would look like something like this:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
-    "raster_filepath = '~/NLCD2011_LC_Pennsylvania.tif'"
+    "raster_filepath = '~/NLCD2011_LC_Pennsylvania.tif'\n",
+    "raster_filepath = 'C:\\\\Users\\\\renan\\\\Desktop\\\\harmonization_osnap\\\\NLCD2011_LC_Pennsylvania\\\\NLCD2011_LC_Pennsylvania.tif'"
    ]
   },
   {
@@ -909,7 +951,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -925,10 +967,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x2c388f55eb8>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x1f6c7099240>"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -949,7 +991,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -964,7 +1006,7 @@
       "Harmonizing extensive variable n_total_pop of the year 2010.\n",
       "Harmonizing extensive variable n_white_under_15 of the year 2010.\n",
       "Harmonizing intensive variable p_white_under_15 of the year 2010.\n",
-      "Time taken (in seconds): 15.817450523376465\n"
+      "Time taken (in seconds): 16.739511728286743\n"
      ]
     }
    ],
@@ -989,7 +1031,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -1094,7 +1136,7 @@
        "4                       0.136141  "
       ]
      },
-     "execution_count": 24,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1119,7 +1161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -1128,7 +1170,7 @@
        "Text(0, 0.5, 'NLCD (area)')"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1152,7 +1194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -1161,7 +1203,7 @@
        "Text(0, 0.5, 'NLCD (area)')"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1185,7 +1227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -1194,7 +1236,7 @@
        "Text(0, 0.5, 'NLCD (area)')"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1214,6 +1256,273 @@
     "plt.title('Interpolated Per. of White Under 15 years', fontsize = 20)\n",
     "plt.xlabel('Area', fontsize = 18)\n",
     "plt.ylabel('NLCD (area)', fontsize = 18)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Constrained Checks (overall population)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1517550.0041874615"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "harmonized_area[harmonized_area.year == '2000'].interpolated_n_total_pop.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1517550.0"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "harmonized_nlcd[harmonized_nlcd.year == '2000'].interpolated_n_total_pop.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1517550"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_phili_2000.n_total_pop.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "95054.00082107751"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "harmonized_area[harmonized_area.year == '2000'].interpolated_n_white_under_15.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "95054.0"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "harmonized_nlcd[harmonized_nlcd.year == '2000'].interpolated_n_white_under_15.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "95054"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_phili_2000.n_white_under_15.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1525811.0035805448"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "harmonized_area[harmonized_area.year == '2010'].interpolated_n_total_pop.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1525811.0"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "harmonized_nlcd[harmonized_nlcd.year == '2010'].interpolated_n_total_pop.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1525811.0"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_phili_2010.n_total_pop.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "64390.00004099"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "harmonized_area[harmonized_area.year == '2010'].interpolated_n_white_under_15.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "64389.999999999985"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "harmonized_nlcd[harmonized_nlcd.year == '2010'].interpolated_n_white_under_15.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "64390.0"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_phili_2010.n_white_under_15.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-75.280266,  39.867004, -74.955763,  40.137992])"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_phili_2010.total_bounds"
    ]
   }
  ],

--- a/examples/harmonizing_community_example.ipynb
+++ b/examples/harmonizing_community_example.ipynb
@@ -611,7 +611,7 @@
      "text": [
       "Help on function harmonize in module tobler.harmonize:\n",
       "\n",
-      "harmonize(raw_community, target_year_of_reference, weights_method='area', extensive_variables=[], intensive_variables=[], allocate_total=True, raster=None, codes=[21, 22, 23, 24], force_crs_match=True)\n",
+      "harmonize(raw_community, target_year_of_reference, weights_method='area', extensive_variables=[], intensive_variables=[], allocate_total=True, raster_path=None, codes=[21, 22, 23, 24], force_crs_match=True)\n",
       "    Harmonize Multiples GeoData Sources with different approaches\n",
       "    \n",
       "    Parameters\n",
@@ -636,13 +636,13 @@
       "    intensive_variables : list\n",
       "        The names of variables in each dataset of raw_community that contains intensive variables to be harmonized (see (2) in Notes).\n",
       "    \n",
-      "    allocate_total: boolean\n",
+      "    allocate_total : boolean\n",
       "        True if total value of source area should be allocated.\n",
       "        False if denominator is area of i. Note that the two cases\n",
       "        would be identical when the area of the source polygon is\n",
       "        exhausted by intersections. See (3) in Notes for more details.\n",
       "        \n",
-      "    raster : the associated raster (from rasterio.open) that has the types of each pixel in the spatial context.\n",
+      "    raster_path : the path to the associated raster image that has the types of each pixel in the spatial context.\n",
       "        Only taken into consideration for harmonization raster based.\n",
       "        \n",
       "    codes : an integer list of codes values that should be considered as 'populated'.\n",
@@ -720,7 +720,7 @@
       "Harmonizing extensive variable n_total_pop of the year 2010.\n",
       "Harmonizing extensive variable n_white_under_15 of the year 2010.\n",
       "Harmonizing intensive variable p_white_under_15 of the year 2010.\n",
-      "Time taken (in seconds): 1.8245913982391357\n"
+      "Time taken (in seconds): 1.883812427520752\n"
      ]
     }
    ],
@@ -893,23 +893,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
-    "filepath = '~/NLCD2011_LC_Pennsylvania.tif'"
+    "raster_filepath = '~/NLCD2011_LC_Pennsylvania.tif'"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Reading the raster file:"
+    "Just for the sake of visualization, we read the raster file:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -925,16 +925,16 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x1c9da5f1ac8>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x2c388f55eb8>"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "penn_raster = rasterio.open(filepath)\n",
+    "penn_raster = rasterio.open(raster_filepath)\n",
     "show(penn_raster, cmap='terrain')"
    ]
   },
@@ -949,7 +949,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -964,7 +964,7 @@
       "Harmonizing extensive variable n_total_pop of the year 2010.\n",
       "Harmonizing extensive variable n_white_under_15 of the year 2010.\n",
       "Harmonizing intensive variable p_white_under_15 of the year 2010.\n",
-      "Time taken (in seconds): 52.693381786346436\n"
+      "Time taken (in seconds): 15.817450523376465\n"
      ]
     }
    ],
@@ -975,7 +975,7 @@
     "                            extensive_variables = ['n_total_pop', 'n_white_under_15'],\n",
     "                            intensive_variables = ['p_white_under_15'],\n",
     "                            weights_method = 'land_type_area',\n",
-    "                            raster = penn_raster)\n",
+    "                            raster_path = raster_filepath)\n",
     "t1 = time.time()\n",
     "print('Time taken (in seconds): {}'.format(t1 - t0))"
    ]
@@ -989,7 +989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -1094,7 +1094,7 @@
        "4                       0.136141  "
       ]
      },
-     "execution_count": 21,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1119,7 +1119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -1128,7 +1128,7 @@
        "Text(0, 0.5, 'NLCD (area)')"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1152,7 +1152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -1161,7 +1161,7 @@
        "Text(0, 0.5, 'NLCD (area)')"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1185,7 +1185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -1194,7 +1194,7 @@
        "Text(0, 0.5, 'NLCD (area)')"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     },

--- a/examples/vectorized_raster_example.ipynb
+++ b/examples/vectorized_raster_example.ipynb
@@ -4,9 +4,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Areal Interpolation of Population Counts Using National Land Cover Data (NLCD) in Python: vectorized raster\n",
-    "\n",
-    "\n",
+    "# Table of Contents\n",
+    "* [Areal Interpolation of Population Counts Using National Land Cover Data (NLCD) in Python: vectorized raster](#Areal-Interpolation-of-Population-Counts-Using-National-Land-Cover-Data-%28NLCD%29-in-Python:-vectorized-raster)\n",
+    "* [Step 1: read the corresponding image](#Step-1:-read-the-corresponding-image)\n",
+    "* [Step 2: read a GeoDataFrame and append population from external source](#Step-2:-read-a-GeoDataFrame-and-append-population-from-external-source)\n",
+    "* [Step 3: create weights from regression for each pixel type](#Step-3:-create-weights-from-regression-for-each-pixel-type)\n",
+    "* [Step 4: create correspondence table for each pixel](#Step-4:-create-correspondence-table-for-each-pixel)\n",
+    "* [Step 5: calculate population from a different tract subdivision](#Step-5:-calculate-population-from-a-different-tract-subdivision)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Areal Interpolation of Population Counts Using National Land Cover Data (NLCD) in Python: vectorized raster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "This is a notebook that presents the functions built that uses the US Geological Survey's National Land Cover Data (NLCD) for population interpolation. This comprises a concise framework to use the NLCD data to estimate population into any spatial extent that the researcher might be interested. This step-by-step procedure can be used, for example, to more accurately harmonize population between two distinct periods of time that might have different spatial extents. For exemple, two different set of census tracts.\n",
     "\n",
     "This was inpired by *Reibel, Michael, and Aditya Agrawal. \"Areal interpolation of population counts using pre-classified land cover data.\" Population Research and Policy Review 26.5-6 (2007): 619-633.*\n",
@@ -41,12 +58,23 @@
     "\n",
     "unzip -d /tmp /tmp/NLCD2011_LC_Pennsylvania.zip\n",
     "\n",
-    "```\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Then in the same directory as this notebook do\n",
     "```\n",
     "ln -s /tmp/NLCD2011_LC_Pennsylvania.tif .\n",
-    "```\n",
-    "\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Now, you need to specify the file path of the unzipped file that would look like something like this:"
    ]
   },

--- a/examples/vectorized_raster_weights_from_regression_explained_example.ipynb
+++ b/examples/vectorized_raster_weights_from_regression_explained_example.ipynb
@@ -4,6 +4,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Table of Contents\n",
+    "* [Regression step from NLCD data explained: vectorized raster](#Regression-step-from-NLCD-data-explained:-vectorized-raster)\n",
+    "\t* [How to build the geography profile of the area of a specific polygon](#How-to-build-the-geography-profile-of-the-area-of-a-specific-polygon)\n",
+    "\t* [How to build the geography profile of an entire GeoDataFrame](#How-to-build-the-geography-profile-of-an-entire-GeoDataFrame)\n",
+    "\t* [Final Step: create population weights for each pixel value according to a regression model](#Final-Step:-create-population-weights-for-each-pixel-value-according-to-a-regression-model)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Regression step from NLCD data explained: vectorized raster"
    ]
   },
@@ -320,7 +331,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### How to build the geography profile of the area of a specific polygon"
+    "## How to build the geography profile of the area of a specific polygon"
    ]
   },
   {
@@ -772,7 +783,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### How to build the geography profile of an entire GeoDataFrame"
+    "## How to build the geography profile of an entire GeoDataFrame"
    ]
   },
   {
@@ -1012,7 +1023,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Final Step: create population weights for each pixel value according to a regression model"
+    "## Final Step: create population weights for each pixel value according to a regression model"
    ]
   },
   {

--- a/tobler/area_weighted.py
+++ b/tobler/area_weighted.py
@@ -13,6 +13,11 @@ from tobler.util.util import _check_crs, _nan_check, _check_presence_of_crs
 
 
 def area_tables_binning(source_df, target_df):
+    
+    if _check_crs(source_df, target_df):
+        pass
+    else:
+        return None
 
     df1 = source_df
     df2 = target_df
@@ -205,6 +210,12 @@ def area_interpolate_binning(
     v_j = \sum_i v_i w_{i,j}
     w_{i,j} = a_{i,j} / \sum_k a_{k,j}
     """
+    
+    if _check_crs(source_df, target_df):
+        pass
+    else:
+        return None
+    
     if table is None:
         table = area_tables_binning(source_df, target_df)
 
@@ -319,6 +330,12 @@ def area_interpolate(
 
 
     """
+    
+    if _check_crs(source_df, target_df):
+        pass
+    else:
+        return None
+    
     if tables is None:
         SU, UT = area_tables(source_df, target_df)
     else:

--- a/tobler/vectorized_raster_interpolation.py
+++ b/tobler/vectorized_raster_interpolation.py
@@ -36,6 +36,7 @@ import shap
 __all__ = ['getFeatures', 
            'return_area_profile', 
            'append_profile_in_gdf', 
+           'fast_append_profile_in_gdf',
            'return_weights_from_regression',
            'return_weights_from_xgboost',
            'create_lon_lat',


### PR DESCRIPTION
- The usage of rasterstats improved `area_tables_raster` function (although it still uses geopandas overlay). Therefore, this PR updates the harmonization notebook with this implementation. In the notebook example, here's the time comparison:

Harmonization before rasterstats: 52.693381786346436 seconds
Harmonization current using rasterstats: 15.817450523376465 seconds

- This also adds the conservative CRS checks for all `area_weighted` based functions.

ps.: I think that, eventually, this branch could be merged into master, although the API might change in the future.

ps2.: I've been wondering if our raster implementations could be leveraged by using something like GeoPySpark https://pt.slideshare.net/lossyrob/analyzing-larger-rasterdata-in-a-jupyter-notebook-with-geopyspark-on-aws-foss4g-2017-workshop